### PR TITLE
Raw selector not returning node list.

### DIFF
--- a/tests/Functional/Selectors/SelectH1Test.php
+++ b/tests/Functional/Selectors/SelectH1Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Migrate\Tests\Functional\Type;
+
+use Migrate\Tests\Functional\CrawlerTestCase;
+use Migrate\Type\Text;
+
+/**
+ * Ensure that the tool can locate a H1.
+ */
+class TestSelectH1 extends CrawlerTestCase
+{
+
+  /**
+   * Ensure that links in the DOM can be found.
+   */
+  public function testSelectH1()
+  {
+    $row = new \stdClass();
+    $type = new Text(
+      $this->getCrawler(),
+      $this->getOutput(),
+      $row,
+      ['field' => 'title', 'selector' => 'h1']
+    );
+
+    $type->process();
+    $this->assertTrue(\property_exists($row, 'title'));
+    $this->assertEquals('This is the primary heading and there should only be one of these per page', $row->title[0]);
+  }
+
+}


### PR DESCRIPTION
Raw selectors weren't working because the logic to determine if the selector was using xpath or css was off. The `evaluate` method can use the valid css selector however it returns an empty `NodeList`. There are times when the `evaluate` method can't parse the given selector and we just recieve an empty array. `TypeBase` was treating `h1` as a valid xpath and as it's not valid xpath it would return an empty NodeList.
    
Fixes #1
