### PR TITLE
Ensures that media process correctly moves configuration values.

### DIFF
--- a/src/Processor/Media.php
+++ b/src/Processor/Media.php
@@ -38,6 +38,7 @@ class Media extends ProcessorOutputBase implements ProcessorInterface
      */
     public function __construct(array $config, Crawler $crawler, OutputInterface $output)
     {
+        parent::__construct($config, $crawler, $output);
 
         $this->type     = isset($config['type']) ? $config['type'] : 'image';
         $this->selector = isset($config['selector']) ? $config['selector'] : 'img';
@@ -51,7 +52,7 @@ class Media extends ProcessorOutputBase implements ProcessorInterface
         $this->config['attributes'] = [];
 
         $this->config['attributes']['data_embed_button']         = !empty($config['data_embed_button']) ? $config['data_embed_button'] : 'tide_media';
-        $this->config['attributes']['data_entity_embed_display'] = !empty($config['data_entity_embed_display']) ? $config['data_embed_button'] : 'view_mode:media.embedded';
+        $this->config['attributes']['data_entity_embed_display'] = !empty($config['data_entity_embed_display']) ? $config['data_entity_embed_display'] : 'view_mode:media.embedded';
         $this->config['attributes']['data_entity_type']          = !empty($config['data_entity_type']) ? $config['data_entity_type'] : 'media';
 
         $this->config['extra'] = isset($config['extra']) ? $config['extra'] : [];
@@ -61,8 +62,6 @@ class Media extends ProcessorOutputBase implements ProcessorInterface
         $this->processors   = isset($config['processors']) ? $config['processors'] : false;
         $this->process_name = isset($config['process_name']) ? $config['process_name'] : false;
         $this->process_file = isset($config['process_file']) ? $config['process_file'] : false;
-
-        parent::__construct($config, $crawler, $output);
 
     }//end __construct()
 

--- a/src/Utility/MediaTrait.php
+++ b/src/Utility/MediaTrait.php
@@ -20,18 +20,18 @@ trait MediaTrait
     /**
      * Accessor for data attributes with default values.
      */
-    public function getEmbededAttributes()
+    public function getEmbeddedAttributes()
     {
         $defaults = [
             'data_embed_button'         => 'tide_media',
             'data_entity_embed_display' => 'view_mode:media.embedded',
             'data_entity_type'          => 'media',
         ];
-
         $attributes = isset($this->config['attributes']) ? $this->config['attributes'] : [];
+
         return array_merge($defaults, $attributes);
 
-    }//end getEmbededAttributes()
+    }//end getEmbeddedAttributes()
 
 
     /**
@@ -115,7 +115,7 @@ trait MediaTrait
     {
         $data = '';
 
-        foreach ($this->getEmbededAttributes() as $attr => $value) {
+        foreach ($this->getEmbeddedAttributes() as $attr => $value) {
             $attr  = strtolower(str_replace('_', '-', $attr));
             $data .= " {$attr}=\"$value\"";
         }

--- a/tests/Functional/Processor/MediaTest.php
+++ b/tests/Functional/Processor/MediaTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Migrate\Tests\Functional\Processor;
+
+use Migrate\Tests\Functional\CrawlerTestCase;
+use Migrate\Processor\Media;
+
+/**
+ * Ensure that the media trait correctly functions.
+ */
+class MediaTest extends CrawlerTestCase
+{
+
+  /**
+   * Ensure that when used as a proceessor getEmbeddedAttributes returns valid.
+   */
+  public function testMediaAttributesProcessor()
+  {
+    $config = [
+      'type' => 'media',
+      'selector' => 'img',
+      'file' => 'src',
+      'name' => 'src',
+      'alt' => 'alt',
+      'data_embed_button' => 'test_media',
+      'data_entity_embed_display' => 'view_mode:media.test',
+      'data_entity_type' => 'test',
+    ];
+
+    $crawler = $this->getCrawler();
+
+    $processor = new Media($config, $crawler, $this->getOutput());
+
+    foreach ($processor->getEmbeddedAttributes() as $ak => $av) {
+      $this->assertEquals($av, $config[$ak], "$ak");
+    }
+  }
+
+  /**
+   * Ensure that the processor value matches whats expected.
+   */
+  public function testProcessorValue()
+  {
+    $config = [
+      'type' => 'media',
+      'selector' => 'img',
+      'file' => 'src',
+      'name' => 'src',
+      'alt' => 'alt',
+      'data_embed_button' => 'test_media',
+      'data_entity_embed_display' => 'view_mode:media.test',
+      'data_entity_type' => 'test',
+    ];
+
+    $crawler = $this->getCrawler();
+
+    $processor = new Media($config, $crawler, $this->getOutput());
+
+    $markup = $crawler->filter('#with-image')->html();
+    $value = $processor->process($markup);
+
+    $this->assertTrue(strpos($value, 'data-embed-button="test_media"') !== FALSE);
+    $this->assertTrue(strpos($value, 'data-entity-type="test"') !== FALSE);
+    $this->assertTrue(strpos($value, 'data-entity-embed-display="view_mode:media.test"') !== FALSE);
+    $this->assertTrue(strpos($value, '<drupal-entity') !== FALSE);
+  }
+
+
+}

--- a/tests/test.html
+++ b/tests/test.html
@@ -747,5 +747,11 @@
         </div>
       </div>
     </div>
+    <div id="with-image">
+      <h2>Media extraction</h2>
+      <p>This is a block of text with an image in it.</p>
+      <img src="https://placehold.it/400x400" alt="test" />
+      <p>Used for testing the media extraction processor.</p>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
The trait expects configuration to be under `attributes` key on the config array. The processors base constructor does variable assignment which was overriding the custom pproperty allocation the processor does to conform with the trait.
 
Fixes #23