### PR TITLE
Add processor support to alias.

### DIFF
--- a/src/Type/Alias.php
+++ b/src/Type/Alias.php
@@ -18,7 +18,10 @@ class Alias extends TypeBase implements TypeInterface
      */
     public function process()
     {
-        $this->addValueToRow(parse_url($this->crawler->getUri(), PHP_URL_PATH));
+
+        $alias = parse_url($this->crawler->getUri(), PHP_URL_PATH);
+        $alias = $this->processValue($alias);
+        $this->addValueToRow($alias);
 
     }//end process()
 

--- a/tests/Functional/Type/AliasTest.php
+++ b/tests/Functional/Type/AliasTest.php
@@ -23,4 +23,24 @@ class AliasTest extends CrawlerTestCase {
     $this->assertEquals('/test', $row->alias);
   }
 
+  public function testAliasProcessors() {
+    $row = new \stdClass;
+    $alias = new Alias(
+      $this->getCrawler(),
+      $this->getOutput(),
+      $row,
+      [
+        'field' => 'alias',
+        'processors' => [
+          'replace' => [
+            'pattern' => '\/test',
+            'replace' => '/replaced',
+          ]
+        ]
+      ]
+    );
+    $alias->process();
+    $this->assertEquals('/replaced', $row->alias);
+  }
+
 }


### PR DESCRIPTION
- Adds `processors` support to the alias type.

Fixes #57 