### PR TITLE
Fix docs so media appears in sidebar

### DIFF
--- a/docs/TypeMedia.md
+++ b/docs/TypeMedia.md
@@ -1,7 +1,7 @@
 ---
-id: type-long-text
-title: Long Text
-sidebar_label: Long Text
+id: type-media
+title: Media
+sidebar_label: Media
 ---
 
 Extract a structured representation of a media asset from the DOM.


### PR DESCRIPTION
The doc file for Media currently has the same ID as LongText which means that media doesn't appear in the sidebar.