### PR TITLE
Add a new group plugin for crawler.

### DIFF
--- a/src/Command/CrawlCommand.php
+++ b/src/Command/CrawlCommand.php
@@ -145,6 +145,10 @@ class CrawlCommand extends Command
       $crawler->setDelayBetweenRequests($delay);
     }
 
+    if (!empty($this->config['options']['ignore_robotstxt'])) {
+      $crawler->ignoreRobots();
+    }
+
     $io->success('Starting crawl!');
 
     $crawler->startCrawling($baseUrl);

--- a/src/Crawler/Group/ElementFilter.php
+++ b/src/Crawler/Group/ElementFilter.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Merlin\Crawler\Group;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Allows regex element filters to extract to separate files.
+ *
+ * @example
+ *   id: group-by-node-type
+ *   type: element_filter
+ *   options:
+ *      selector: .node # DOM or Xpath
+ *      pattern: /node-\w+/
+ *      filter_attr: class
+ */
+class ElementFilter extends GroupBase
+{
+
+  protected $filter_type;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $config=[])
+  {
+    parent::__construct($config);
+    $this->filter_type = NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getId() : string
+  {
+    $id = parent::getId();
+
+    if ($this->filter_type) {
+      $id .= "-{$this->filter_type}";
+    }
+
+    return $id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function match($url, ResponseInterface $response) : bool
+  {
+    $dom = new Crawler($response->getBody()->__toString(), $url);
+    $filter_attr = $this->getOption('filter_attr') ?: 'class';
+    $pattern = $this->getOption('pattern');
+
+    if (empty($this->getOption('selector')) || empty($pattern)) {
+      return FALSE;
+    }
+
+    try {
+      $element = $dom->evaluate($this->getOption('selector'));
+    } catch (\Exception $error) {
+      $element = [];
+    }
+
+    if (!is_callable([$element, 'count']) || $element->count() === 0) {
+      try {
+        $element = $dom->filter($this->getOption('selector'));
+      } catch (\Exception $error) {
+        return FALSE;
+      }
+    }
+
+    if ($element->count() === 0) {
+      return FALSE;
+    }
+
+     $types = $element->each(function(Crawler $node) use ($filter_attr, $pattern) {
+      preg_match($pattern, $node->attr($filter_attr), $matches);
+      return reset($matches);
+    });
+
+    $this->filter_type = reset($types);
+
+    return TRUE;
+  }
+
+
+}

--- a/src/Crawler/Group/ElementFilter.php
+++ b/src/Crawler/Group/ElementFilter.php
@@ -19,7 +19,13 @@ use Symfony\Component\DomCrawler\Crawler;
 class ElementFilter extends GroupBase
 {
 
+  /**
+   * The filtered type - used to separate output by id.
+   *
+   * @var string
+   */
   protected $filter_type;
+
 
   /**
    * {@inheritdoc}
@@ -28,7 +34,9 @@ class ElementFilter extends GroupBase
   {
     parent::__construct($config);
     $this->filter_type = NULL;
-  }
+
+  }//end __construct()
+
 
   /**
    * {@inheritdoc}
@@ -42,7 +50,9 @@ class ElementFilter extends GroupBase
     }
 
     return $id;
-  }
+
+  }//end getId()
+
 
   /**
    * {@inheritdoc}
@@ -75,15 +85,18 @@ class ElementFilter extends GroupBase
       return FALSE;
     }
 
-     $types = $element->each(function(Crawler $node) use ($filter_attr, $pattern) {
-      preg_match($pattern, $node->attr($filter_attr), $matches);
-      return reset($matches);
-    });
+    $types = $element->each(
+        function(Crawler $node) use ($filter_attr, $pattern) {
+        preg_match($pattern, $node->attr($filter_attr), $matches);
+        return reset($matches);
+        }
+    );
 
     $this->filter_type = reset($types);
 
     return TRUE;
-  }
+
+  }//end match()
 
 
-}
+}//end class


### PR DESCRIPTION
Adds a new crawler to help identify types based on regular expression attribute determining. The main idea around this is more using Merlin's crawler to quickly give indicative numbers of page types based on element and attribute filtering.

The example below is used to identify content types using standard Drupal outputs.

*Example config*
```
groups:
    -
      id: node
      type: element_filter
      options:
        selector: body
        filter_attr: class
        pattern: '/node-type-\w+/'
```

Output:
```
Generating /tmp/test/crawled-urls-node_node.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-page.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-landing.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-webform.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-news.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-footer.yml Done!
Generating /tmp/test/crawled-urls-node_redirects.yml Done!
Generating /tmp/test/crawled-urls-node_default.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-consultation.yml Done!
Generating /tmp/test/crawled-urls-node_node-node-type-literature.yml Done!
Generating /tmp/test/crawl-error-node.yml Done!
```
