### PR TITLE
Added allowing a custom report.

### DIFF
--- a/src/Reporting/MigrateReport.php
+++ b/src/Reporting/MigrateReport.php
@@ -974,6 +974,11 @@ class MigrateReport
         return new MigrateReportMedia($io, $dstDomain, $srcDomain, $options);
         break;
       default:
+        $class = 'Merlin\\Reporting\\MigrateReport' . str_replace('_', '', ucwords($type, '_'));
+        if(class_exists($class))
+        {
+          return new $class($io, $dstDomain, $srcDomain, $options);
+        }
         throw new \Exception("Unknown report type: '{$type}'  Aborting.");
         exit(1);
     }

--- a/src/Reporting/MigrateReport.php
+++ b/src/Reporting/MigrateReport.php
@@ -974,9 +974,8 @@ class MigrateReport
         return new MigrateReportMedia($io, $dstDomain, $srcDomain, $options);
         break;
       default:
-        $class = 'Merlin\\Reporting\\MigrateReport' . str_replace('_', '', ucwords($type, '_'));
-        if(class_exists($class))
-        {
+        $class = 'Merlin\\Reporting\\MigrateReport'.str_replace('_', '', ucwords($type, '_'));
+        if (class_exists($class)) {
           return new $class($io, $dstDomain, $srcDomain, $options);
         }
         throw new \Exception("Unknown report type: '{$type}'  Aborting.");


### PR DESCRIPTION
The change allows providing a custom report class as `MigrateReportYourCustomName`, where `YourCustomName` is the `type: your_custom_name`.


Note that almost all members of the current `MigrateReport` class are `private` so it is not possible to simply extend the class to override parts of the functionality. Instead - the whole class needs to be cloned and named as a new report. :(