### PR TITLE
Symfony Console Component Return Type Missing in Generate Command

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -128,6 +128,8 @@ class GenerateCommand extends Command
 
         $output->writeln("<comment>Completed in ".(microtime(true) - $start)."</comment>");
 
+        return 0;
+
     }//end execute()
 
 


### PR DESCRIPTION

Symfony Console Component Return Type Missing in Generate Command

https://github.com/symfony/console/blob/7.0/Command/Command.php#L282


Similar fix was added for crawl command, seems to be missed to add for generate. 
https://github.com/salsadigitalauorg/merlin-framework/blob/develop/src/Command/CrawlCommand.php#L174



![Screenshot 2024-03-13 at 5 53 58 PM](https://github.com/salsadigitalauorg/merlin-framework/assets/14798955/e29a6565-289a-41df-b8db-582995efcb06)

